### PR TITLE
Ignore classes from testCompile tasks as mentioned in bug #3. Correctly declare task inputs and outputs to allow up-to-date checks.

### DIFF
--- a/src/main/java/org/jayware/gradle/osgi/ds/GenerateDeclarativeServicesDescriptorsTask.java
+++ b/src/main/java/org/jayware/gradle/osgi/ds/GenerateDeclarativeServicesDescriptorsTask.java
@@ -52,11 +52,9 @@ extends DefaultTask
 
     private final Project project;
 
-    @InputFiles
-    final List<FileCollection> input = new ArrayList<>();
+    private final List<FileCollection> input = new ArrayList<>();
 
-    @OutputDirectory
-    File outputDirectory;
+    private File outputDirectory;
 
     public GenerateDeclarativeServicesDescriptorsTask()
     {
@@ -156,8 +154,22 @@ extends DefaultTask
 
         return scrOptions;
     }
+    
+    @OutputDirectory
+    public File getOutputDirectory() {
+		return outputDirectory;
+	}
 
-    private static class GenerationSource
+	public void setOutputDirectory(File outputDirectory) {
+		this.outputDirectory = outputDirectory;
+	}
+
+	@InputFiles
+	public List<FileCollection> getInput() {
+		return input;
+	}
+
+	private static class GenerationSource
     implements Source
     {
         private final String myClassName;

--- a/src/main/java/org/jayware/gradle/osgi/ds/OsgiDsPlugin.java
+++ b/src/main/java/org/jayware/gradle/osgi/ds/OsgiDsPlugin.java
@@ -22,7 +22,6 @@ import org.gradle.api.tasks.bundling.AbstractArchiveTask;
 import org.gradle.api.tasks.compile.AbstractCompile;
 
 import java.io.File;
-import java.util.function.Consumer;
 
 
 public class OsgiDsPlugin
@@ -38,22 +37,19 @@ implements Plugin<Project>
 
         task.setGroup(BasePlugin.BUILD_GROUP);
         task.setDescription("Generates OSGi Declarative Services XML descriptors");
-        task.outputDirectory = new File(project.getBuildDir(), "/tmp/osgi-ds");
+        task.setOutputDirectory(new File(project.getBuildDir(), "/tmp/osgi-ds"));
 
-        project.getTasks().withType(AbstractCompile.class).forEach(new Consumer<AbstractCompile>()
+        project.getTasks().withType(AbstractCompile.class).forEach(compileTask -> 
         {
-            @Override
-            public void accept(AbstractCompile compileTask)
-            {
-                task.input.add(project.files(compileTask));
-                task.mustRunAfter(compileTask);
-            }
+        	if(!compileTask.getName().toLowerCase().contains("test")){ // exclude testCompile
+	            task.getInput().add(project.files(compileTask));
+	            task.mustRunAfter(compileTask);
+        	}
         });
 
         if (archiveTask != null)
         {
             archiveTask.from(task);
-            archiveTask.from(task.outputDirectory);
         }
     }
 }


### PR DESCRIPTION
This pull request fixes two bugs:

- #3 test classes where added to the task input files thus causing a `ClassNotFoundException`
- The annotations `@InputFiles` and `@OutputDirectory` were declared on fields which were no proper Java bean properties. Therefore they could not be recognized by Gradle and the up-to-date check did not work properly. I declared fields as private and added setters and getters.