### PR TITLE
Update to modern Gradle APIs

### DIFF
--- a/src/main/java/org/jayware/gradle/osgi/ds/OsgiDsPlugin.java
+++ b/src/main/java/org/jayware/gradle/osgi/ds/OsgiDsPlugin.java
@@ -17,39 +17,21 @@ package org.jayware.gradle.osgi.ds;
 
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
-import org.gradle.api.plugins.BasePlugin;
-import org.gradle.api.tasks.bundling.AbstractArchiveTask;
-import org.gradle.api.tasks.compile.AbstractCompile;
+import org.gradle.api.tasks.SourceSetContainer;
+import org.gradle.api.tasks.TaskProvider;
 
-import java.io.File;
-
-
-public class OsgiDsPlugin
-implements Plugin<Project>
-{
-    public static final String GENERATE_DESCRIPTORS_TASK_NAME = "generateDeclarativeServicesDescriptors";
-
+public class OsgiDsPlugin implements Plugin<Project> {
     @Override
-    public void apply(Project project)
-    {
-        final GenerateDeclarativeServicesDescriptorsTask task = project.getTasks().create(GENERATE_DESCRIPTORS_TASK_NAME, GenerateDeclarativeServicesDescriptorsTask.class);
-        final AbstractArchiveTask archiveTask = (AbstractArchiveTask) project.getTasks().findByName("jar");
-
-        task.setGroup(BasePlugin.BUILD_GROUP);
-        task.setDescription("Generates OSGi Declarative Services XML descriptors");
-        task.setOutputDirectory(new File(project.getBuildDir(), "/tmp/osgi-ds"));
-
-        project.getTasks().withType(AbstractCompile.class).forEach(compileTask -> 
-        {
-        	if(!compileTask.getName().toLowerCase().contains("test")){ // exclude testCompile
-	            task.getInput().add(project.files(compileTask));
-	            task.mustRunAfter(compileTask);
-        	}
-        });
-
-        if (archiveTask != null)
-        {
-            archiveTask.from(task);
-        }
+    public void apply(Project project) {
+        project.getExtensions().configure(SourceSetContainer.class, sourceSets -> sourceSets.configureEach(sourceSet -> {
+            String taskName = sourceSet.getTaskName("generate", "DeclarativeServicesDescriptors");
+            TaskProvider<GenerateDeclarativeServicesDescriptorsTask> generateTask = project.getTasks().register(taskName, GenerateDeclarativeServicesDescriptorsTask.class, task -> {
+                task.setDescription("Generate OSGi Declarative Services XML descriptors for " + sourceSet.getName() + " classes");
+                task.getInputFiles().from(sourceSet.getOutput().getClassesDirs());
+                task.getClasspath().from(sourceSet.getRuntimeClasspath());
+                task.getOutputDirectory().set(project.getLayout().getBuildDirectory().dir("generated/resources/osgi-ds/" + sourceSet.getName()));
+            });
+            sourceSet.getOutput().getGeneratedSourcesDirs().plus(project.fileTree(generateTask));
+        }));
     }
 }


### PR DESCRIPTION
As part of a significant upgrade of a Gradle build system I maintain I found myself needing to:
1. Fix a bug around unclosed `URLClassLoader` instance and some kind of bad interaction with Gradle daemons.
2. Support multiple source-sets and multiple resultant artifacts.

I ended up rewriting the bulk of the plugin with a tighter integration with the source-set concept, and with more aggressive use of the more recent lazy-evaluation concepts in Gradle.

This pull request is the result of that rewrite. I'm not suggesting this needs to be merged verbatim, but I figured I would offer the result here in case it is of interest.